### PR TITLE
Remove duplicate keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,8 @@
   "keywords": [
     "test",
     "framework",
-    "test",
-    "framework",
     "TypeScript",
     "node",
-    "test",
-    "case",
     "case"
   ],
   "author": "James Richford <=> (=)",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,15 @@
   "keywords": [
     "test",
     "framework",
+    "test framework",
     "TypeScript",
     "node",
-    "case"
+    "test case",
+    "case",
+    "unit test",
+    "tap",
+    "junit",
+    "nunit"
   ],
   "author": "James Richford <=> (=)",
   "license": "MIT",


### PR DESCRIPTION
In `package.json` there are some duplicate keywords.

`test` is given three times, `framework` twice and `case` twice.